### PR TITLE
script: deploy and link constants

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,7 +1,15 @@
 const hre = require("hardhat");
 
 async function main() {
-  const Floot = await hre.ethers.getContractFactory("Floot");
+  const FlootConstants = await hre.ethers.getContractFactory("FlootConstants");
+  const constants = await FlootConstants.deploy();
+  await constants.deployed();
+
+  const Floot = await hre.ethers.getContractFactory("Floot", {
+    libraries: {
+      FlootConstants: constants.address,
+    },
+  });
   const floot = await Floot.deploy(
     "0x9ce720d21dd03123c0c2199e0c5433d01c7ac64ab729b1ec57de813014cce8bf",
     24 * 60 * 60, // guardianWindowDurationSeconds = 1 day


### PR DESCRIPTION
When I tried to deploy I got an error saying that `FlootConstants` is not linked. I've updated the deploy script to deploy and link it before deploying the main contract.